### PR TITLE
Adjust for issue #8 - suspected dynamically resizing preventing centering

### DIFF
--- a/bin/gosu-examples
+++ b/bin/gosu-examples
@@ -16,8 +16,8 @@ Example.load_examples "*.rb"
 
 class ExampleBox < Gosu::Window
   def initialize
-    super WIDTH, HEIGHT, :fullscreen => ARGV.include?('--fullscreen')
-    
+    super (WIDTH/2)+WIDTH, HEIGHT, :fullscreen => ARGV.include?('--fullscreen')
+
     @sidebar = Sidebar.new { |example| change_example(example) }
     
     welcome_class = Example.examples.find { |example| example.name =~ /::Welcome$/ }

--- a/bin/gosu-examples
+++ b/bin/gosu-examples
@@ -10,11 +10,13 @@ $LOAD_PATH << "#{File.dirname __FILE__}/../lib/gosu-examples"
 require 'example'
 require 'sidebar'
 
+WIDTH, HEIGHT = 640, 480
+
 Example.load_examples "*.rb"
 
 class ExampleBox < Gosu::Window
   def initialize
-    super Sidebar::WIDTH, Sidebar::HEIGHT, :fullscreen => ARGV.include?('--fullscreen')
+    super WIDTH, HEIGHT, :fullscreen => ARGV.include?('--fullscreen')
     
     @sidebar = Sidebar.new { |example| change_example(example) }
     


### PR DESCRIPTION
This will have to be confirmed working on other platforms.

I do not think the dynamic resizing was the issue but:

1. The original gosu-example used the sidebars width instead of the welcome.rb width.

2. When setting resolution and not defining x,y you start drawing the window from that point and towards the right, additionally this main window appends a window to the left of a window drawn not taking into consideration the misplacement of the first windows width.

solution:
Defining width/2+width you effectively center the width on itself.

--

Either that or i'm completely off. but it seems reasonable.