### PR TITLE
Minor font deprecation warning

### DIFF
--- a/examples/chipmunk_integration.rb
+++ b/examples/chipmunk_integration.rb
@@ -257,7 +257,7 @@ class ChipmunkIntegration < (Example rescue Gosu::Window)
     @background_image.draw(0, 0, ZOrder::Background)
     @player.draw
     @stars.each { |star| star.draw }
-    @font.draw("Score: #{@score}", 10, 10, ZOrder::UI, 1.0, 1.0, 0xff_ffff00)
+    @font.draw_text("Score: #{@score}", 10, 10, ZOrder::UI, 1.0, 1.0, 0xff_ffff00)
   end
 
   def button_down(id)

--- a/examples/opengl_integration.rb
+++ b/examples/opengl_integration.rb
@@ -215,7 +215,7 @@ class OpenGLIntegration < (Example rescue Gosu::Window)
   def draw
     @player.draw
     @stars.each { |star| star.draw }
-    @font.draw("Score: #{@player.score}", 10, 10, ZOrder::UI, 1.0, 1.0, 0xff_ffff00)
+    @font.draw_text("Score: #{@player.score}", 10, 10, ZOrder::UI, 1.0, 1.0, 0xff_ffff00)
     @gl_background.draw(ZOrder::Background)
   end
 end

--- a/examples/text_input.rb
+++ b/examples/text_input.rb
@@ -73,7 +73,7 @@ class TextField < Gosu::TextInput
     end
 
     # Finally, draw the text itself!
-    FONT.draw self.text, x, y, z
+    FONT.draw_text self.text, x, y, z
   end
   
   def height

--- a/examples/tutorial.rb
+++ b/examples/tutorial.rb
@@ -118,7 +118,7 @@ class Tutorial < (Example rescue Gosu::Window)
     @background_image.draw(0, 0, ZOrder::BACKGROUND)
     @player.draw
     @stars.each { |star| star.draw }
-    @font.draw("Score: #{@player.score}", 10, 10, ZOrder::UI, 1.0, 1.0, Gosu::Color::YELLOW)
+    @font.draw_text("Score: #{@player.score}", 10, 10, ZOrder::UI, 1.0, 1.0, Gosu::Color::YELLOW)
   end
   
   def button_down(id)


### PR DESCRIPTION
Got deprecation warnings on gosu version 0.14.5  relating to the font draw method.

```
DEPRECATION WARNING: draw is deprecated; use Font#draw_text or Font#draw_markup instead.
draw called from text_input.rb:76:in `draw'.
```
