### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Some examples require the following additional libraries:
 ```bash
 gem install chipmunk
 gem install rmagick
-gem install opengl
+gem install opengl-bindings
 ```

--- a/examples/opengl_integration.rb
+++ b/examples/opengl_integration.rb
@@ -6,7 +6,9 @@
 # used as textures using the gl_tex_info call.
 
 require "gosu"
-require "gl"
+require "opengl"
+
+OpenGL.load_lib
 
 WIDTH, HEIGHT = 640, 480
 
@@ -28,7 +30,7 @@ class GLBackground
     @scrolls = 0
     @height_map = Array.new(POINTS_Y) { Array.new(POINTS_X) { rand } }
   end
-  
+
   def scroll
     @scrolls += 1
     if @scrolls == SCROLLS_PER_STEP
@@ -37,22 +39,22 @@ class GLBackground
       @height_map.push Array.new(POINTS_X) { rand }
     end
   end
-  
+
   def draw(z)
     # gl will execute the given block in a clean OpenGL environment, then reset
     # everything so Gosu's rendering can take place again.
     Gosu.gl(z) { exec_gl }
   end
-  
+
   private
-  
-  include Gl
-  
+
+  include OpenGL
+
   def exec_gl
     glClearColor(0.0, 0.2, 0.5, 1.0)
     glClearDepth(0)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-    
+
     # Get the name of the OpenGL texture the Image resides on, and the
     # u/v coordinates of the rect it occupies.
     # gl_tex_info can return nil if the image was too large to fit onto
@@ -61,7 +63,7 @@ class GLBackground
     return unless info
 
     # Pretty straightforward OpenGL code.
-    
+
     glDepthFunc(GL_GEQUAL)
     glEnable(GL_DEPTH_TEST)
     glEnable(GL_BLEND)
@@ -72,13 +74,13 @@ class GLBackground
 
     glMatrixMode(GL_MODELVIEW)
     glLoadIdentity
-    glTranslate(0, 0, -4)
-  
+    glTranslatef(0, 0, -4)
+
     glEnable(GL_TEXTURE_2D)
     glBindTexture(GL_TEXTURE_2D, info.tex_name)
-    
+
     offs_y = 1.0 * @scrolls / SCROLLS_PER_STEP
-    
+
     0.upto(POINTS_Y - 2) do |y|
       0.upto(POINTS_X - 2) do |x|
         glBegin(GL_TRIANGLE_STRIP)
@@ -91,7 +93,7 @@ class GLBackground
           glColor4d(1, 1, 1, z)
           glTexCoord2d(info.left, info.bottom)
           glVertex3d(-0.5 + (x - 0.0) / (POINTS_X-1), -0.5 + (y - offs_y + 1.0) / (POINTS_Y-2), z)
-        
+
           z = @height_map[y][x + 1]
           glColor4d(1, 1, 1, z)
           glTexCoord2d(info.right, info.top)
@@ -110,7 +112,7 @@ end
 # Roughly adapted from the tutorial game. Always faces north.
 class Player
   Speed = 7
-  
+
   attr_reader :score
 
   def initialize(x, y)
@@ -123,23 +125,23 @@ class Player
   def move_left
     @x = [@x - Speed, 0].max
   end
-  
+
   def move_right
     @x = [@x + Speed, WIDTH].min
   end
-  
+
   def accelerate
     @y = [@y - Speed, 50].max
   end
-  
+
   def brake
     @y = [@y + Speed, HEIGHT].min
   end
-  
+
   def draw
     @image.draw(@x - @image.width / 2, @y - @image.height / 2, ZOrder::Player)
   end
-  
+
   def collect_stars(stars)
     stars.reject! do |star|
       if Gosu.distance(@x, @y, star.x, star.y) < 35
@@ -157,7 +159,7 @@ end
 # for extra rotation coolness!
 class Star
   attr_reader :x, :y
-  
+
   def initialize(animation)
     @animation = animation
     @color = Gosu::Color.new(0xff_000000)
@@ -168,11 +170,11 @@ class Star
     @y = 0
   end
 
-  def draw  
+  def draw
     img = @animation[Gosu.milliseconds / 100 % @animation.size];
     img.draw_rot(@x, @y, ZOrder::Stars, @y, 0.5, 0.5, 1, 1, @color, :add)
   end
-  
+
   def update
     # Move towards bottom of screen
     @y += 3
@@ -184,31 +186,31 @@ end
 class OpenGLIntegration < (Example rescue Gosu::Window)
   def initialize
     super WIDTH, HEIGHT
-    
+
     self.caption = "OpenGL Integration"
-    
+
     @gl_background = GLBackground.new
-    
+
     @player = Player.new(400, 500)
-    
+
     @star_anim = Gosu::Image::load_tiles("media/star.png", 25, 25)
     @stars = Array.new
-    
+
     @font = Gosu::Font.new(20)
   end
-  
+
   def update
     @player.move_left  if Gosu.button_down? Gosu::KB_LEFT  or Gosu.button_down? Gosu::GP_LEFT
     @player.move_right if Gosu.button_down? Gosu::KB_RIGHT or Gosu.button_down? Gosu::GP_RIGHT
     @player.accelerate if Gosu.button_down? Gosu::KB_UP    or Gosu.button_down? Gosu::GP_UP
     @player.brake      if Gosu.button_down? Gosu::KB_DOWN  or Gosu.button_down? Gosu::GP_DOWN
-    
+
     @player.collect_stars(@stars)
-    
+
     @stars.reject! { |star| !star.update }
-    
+
     @gl_background.scroll
-    
+
     @stars.push(Star.new(@star_anim)) if rand(20) == 0
   end
 

--- a/examples/text_input.rb
+++ b/examples/text_input.rb
@@ -24,31 +24,31 @@ class TextField < Gosu::TextInput
   WIDTH = 350
   LENGTH_LIMIT = 20
   PADDING = 5
-  
+
   INACTIVE_COLOR  = 0xcc_666666
   ACTIVE_COLOR    = 0xcc_ff6666
   SELECTION_COLOR = 0xcc_0000ff
   CARET_COLOR     = 0xff_ffffff
-  
+
   attr_reader :x, :y
-  
+
   def initialize(window, x, y)
     # It's important to call the inherited constructor.
     super()
-    
+
     @window, @x, @y = window, x, y
-    
+
     # Start with a self-explanatory text in each field.
     self.text = "Click to edit"
   end
-  
+
   # In this example, we use the filter method to prevent the user from entering a text that exceeds
   # the length limit. However, you can also use this to blacklist certain characters, etc.
   def filter new_text
     allowed_length = [LENGTH_LIMIT - text.length, 0].max
     new_text[0, allowed_length]
   end
-  
+
   def draw(z)
     # Change the background colour if this is the currently selected text field.
     if @window.text_input == self
@@ -57,12 +57,12 @@ class TextField < Gosu::TextInput
       color = INACTIVE_COLOR
     end
     Gosu.draw_rect x - PADDING, y - PADDING, WIDTH + 2 * PADDING, height + 2 * PADDING, color, z
-    
+
     # Calculate the position of the caret and the selection start.
     pos_x = x + FONT.text_width(self.text[0...self.caret_pos])
     sel_x = x + FONT.text_width(self.text[0...self.selection_start])
     sel_w = pos_x - sel_x
-    
+
     # Draw the selection background, if any. (If not, sel_x and pos_x will be
     # the same value, making this a no-op call.)
     Gosu.draw_rect sel_x, y, sel_w, height, SELECTION_COLOR, z
@@ -75,7 +75,7 @@ class TextField < Gosu::TextInput
     # Finally, draw the text itself!
     FONT.draw_text self.text, x, y, z
   end
-  
+
   def height
     FONT.height
   end
@@ -85,7 +85,7 @@ class TextField < Gosu::TextInput
     @window.mouse_x > x - PADDING and @window.mouse_x < x + WIDTH + PADDING and
       @window.mouse_y > y - PADDING and @window.mouse_y < y + height + PADDING
   end
-  
+
   # Tries to move the caret to the position specifies by mouse_x
   def move_caret_to_mouse
     # Test character by character
@@ -104,24 +104,24 @@ class TextInputDemo < (Example rescue Gosu::Window)
   def initialize
     super 640, 480
     self.caption = "Text Input Demo"
-    
-    
+
+
     text =
       "This demo explains (in the source code) how to use the Gosu::TextInput API by building a little TextField class around it.
-      
+
       Each text field can take up to 30 characters, and you can use Tab to switch between them.
 
       As in every example, press <b>E</b> to look at the source code."
-    
+
     # Remove all leading spaces so the text is left-aligned
     text.gsub! /^ +/, ""
-    
-    @text = Gosu::Image.from_text text, 20, width: 540
-        
+
+    @text = Gosu::Image.from_markup text, 20, width: 540
+
     # Set up an array of three text fields.
     @text_fields = Array.new(3) { |index| TextField.new(self, 50, 300 + index * 50) }
   end
-  
+
   def needs_cursor?
     true
   end
@@ -130,7 +130,7 @@ class TextInputDemo < (Example rescue Gosu::Window)
     @text.draw 50, 50, 0
     @text_fields.each { |tf| tf.draw(0) }
   end
-  
+
   def button_down(id)
     if id == Gosu::KB_TAB
       # Tab key will not be 'eaten' by text fields; use for switching through

--- a/examples/welcome.rb
+++ b/examples/welcome.rb
@@ -6,49 +6,49 @@ WIDTH, HEIGHT = 640, 480
 
 class Welcome < (Example rescue Gosu::Window)
   PADDING = 20
-  
+
   def initialize
     super WIDTH, HEIGHT
-    
+
     self.caption = "Welcome!"
-    
+
     text =
       "<b>Welcome to the Gosu Example Box!</b>
-      
+
       This little tool lets you launch any of Gosu’s example games from the list on the right hand side of the screen.
-      
+
       Every example can be run both from this tool <i>and</i> from the terminal/command line as a stand-alone Ruby script.
-      
+
       Keyboard shortcuts:
-      
+
       • To see the source code of an example or feature demo, press <b>E</b>.
       • To open the ‘examples’ folder, press <b>O</b>.
       • To quit this tool, press <b>Esc</b>.
       • To toggle fullscreen mode, press <b>Alt+Enter</b> (Windows, Linux) or <b>cmd+F</b> (macOS).
-      
+
       Why not take a look at the code for this example right now? Simply press <b>E</b>."
-    
+
     # Remove all leading spaces so the text is left-aligned
     text.gsub! /^ +/, ""
-    
-    @text = Gosu::Image.from_text text, 20, width: WIDTH - 2 * PADDING
-    
+
+    @text = Gosu::Image.from_markup text, 20, width: WIDTH - 2 * PADDING
+
     @background = Gosu::Image.new "media/space.png"
   end
-  
+
   def draw
     draw_rotating_star_backgrounds
-    
+
     @text.draw PADDING, PADDING, 0
   end
-  
+
   def draw_rotating_star_backgrounds
     # Disregard the math in this method, it doesn't look as good as I thought it
     # would. =(
-    
+
     angle = Gosu.milliseconds / 50.0
     scale = (Gosu.milliseconds % 1000) / 1000.0
-    
+
     [1, 0].each do |extra_scale|
       @background.draw_rot WIDTH * 0.5, HEIGHT * 0.75, 0, angle, 0.5, 0.5,
         scale + extra_scale, scale + extra_scale

--- a/lib/gosu-examples/example.rb
+++ b/lib/gosu-examples/example.rb
@@ -2,23 +2,23 @@ class Example
   attr_accessor :caption
   attr_reader :width, :height
   attr_writer :parent_window
-  
+
   def initialize(width, height, *options)
     @width, @height = width, height
   end
-  
+
   def draw
   end
-  
+
   def update
   end
-  
+
   def button_down(id)
   end
-  
+
   def button_up(id)
   end
-  
+
   def close
     # no-op, examples cannot close the containing window.
   end
@@ -26,53 +26,53 @@ class Example
   def mouse_x
     @parent_window && @parent_window.mouse_x
   end
-  
+
   def mouse_y
     @parent_window && @parent_window.mouse_y
   end
-  
+
   def text_input
     @parent_window && @parent_window.text_input
   end
-  
+
   def text_input=(text_input)
     @parent_window && @parent_window.text_input = text_input
   end
-  
+
   def self.current_source_file
     @current_source_file
   end
-  
+
   def self.current_source_file=(current_source_file)
     @current_source_file = current_source_file
   end
-  
+
   def self.inherited(subclass)
     @@examples ||= {}
     @@examples[subclass] = self.current_source_file
   end
-  
+
   def self.examples
     @@examples.keys
   end
-  
+
   def self.source_file
     @@examples[self]
   end
-  
+
   def self.initial_example
     @@examples.keys.find { |cls| cls.name.end_with? "::Welcome" }
   end
-  
+
   def self.load_examples(pattern)
-    Dir.glob(pattern) do |file| 
+    Dir.glob(pattern) do |file|
       begin
         # Remember which file we are loading.
         Example.current_source_file = File.expand_path(file)
 
         # Load the example in a sandbox module (second parameter to load()). This way, examples can
         # define classes and constants with the same names, and they will not collide.
-        # 
+        #
         # load() does not let us refer to the anonymous module it creates, but we can enumerate all
         # loaded examples using Example.examples thanks to the "inherited" callback above.
         load file, true


### PR DESCRIPTION
* Fix Welcome and TextInput examples markup being rendered instead of parsed (`.draw_text` -> `.draw_markup`)
* Replace `opengl` gem with `opengl-bindings` (More up to date, less likely to break between Ruby versions; Uses FFI)